### PR TITLE
fix up some docker section wording

### DIFF
--- a/adoptingerlang.org
+++ b/adoptingerlang.org
@@ -1269,7 +1269,7 @@ RUN rebar3 compile
 
 Because of the order of operations in the Dockerfile each run of =docker build .= only compiles the project's source, assuming there is a change, otherwise an existing layer is used here as well. Any command that doesn't need to be rerun if there are changes to the project need to come before either of the =COPY= commands. For example, installing Alpine packages needed by later steps =RUN apk add --no-cache git=.
 
-We will make use of the =--cache-from= argument. When Docker builds layers, =--cache-from= specifies an image name to use a cache to find the layer already built. If the image isn't found locally it will be pulled from te registry. If it isn't in the registry Docker will ignore it. The argument can be given multiple times, making multiple images potential sources of cached layers.
+We will make use of the =--cache-from= argument. When Docker builds layers, =--cache-from= specifies an image name to use as a cache to find the layer already built. If the image isn't found locally it will be pulled from the registry. If it isn't in the registry Docker will ignore it. The argument can be given multiple times, making multiple images potential sources of cached layers.
 
 Now this is all well and good but the layer with the built dependencies that will not be used if =rebar.config= or =rebar.lock= is changed also contains the Hex package cache rebar3 creates under =~/.cache/rebar3/hex=. Any change to those two files will result in all the packages having to be downloaded again.
 


### PR DESCRIPTION
I'm not sure what to do about the fact we should probably talk about using the PLT image and builder image in tests when the test chapter comes before docker and I don't think it fits to explain everything that is in the docker chapter in the test part instead of the production part.