### PR TITLE
add custom hugo/netlify image for publishing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,9 +69,10 @@ workflows:
           deploy_args: "--prod"
           requires:
             - export
-          branches:
-            only:
-            - master
+          filters:
+            branches:
+              only:
+                - master
 
       - pdf:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,8 +4,17 @@ jobs:
     docker:
       - image: silex/emacs:26.2-alpine
     steps:
+      - restore_cache:
+          keys:
+            - emacs-packages-v1
       - checkout
       - run: emacs -batch adoptingerlang.org -q -l export.el
+
+      - save_cache:
+          key: emacs-packages-v1
+          paths:
+            - /root/.emacs.d
+
       - persist_to_workspace:
           root: .
           paths:
@@ -15,29 +24,21 @@ jobs:
           path: ./adoptingerlang.tex
       - store_artifacts:
           path: ./content
+
   deploy:
+    parameters:
+      deploy_args:
+        type: string
+        default: ""
     docker:
-      - image: circleci/node
-        entrypoint: /bin/sh
+      - image: docker.pkg.github.com/tsloughter/adoptingerlang/hugo_netlify
     steps:
       - checkout
-      - run:
-          name: "Pull Submodules"
-          command: |
-            git submodule init
-            git submodule update --remote
       - attach_workspace:
           at: .
       - run: |
-          sudo apt-get install -f python-pygments
-
-          mkdir -p bin
-          curl -L https://github.com/gohugoio/hugo/releases/download/v0.55.5/hugo_extended_0.55.5_Linux-64bit.tar.gz -o bin/hugo.tar.gz
-          tar -xvf bin/hugo.tar.gz -C ./bin
-          bin/hugo --gc --minify
-
-          sudo npm install netlify-cli -g --unsafe-perm
-          netlify deploy --auth $NETLIFY_AUTH_TOKEN --site $NETLIFY_SITE_ID
+          /opt/hugo --gc --minify
+          netlify deploy << parameters.deploy_args >> --auth $NETLIFY_AUTH_TOKEN --site $NETLIFY_SITE_ID
 
   pdf:
     docker:
@@ -59,9 +60,19 @@ workflows:
   hugo_export:
     jobs:
       - export
+
       - deploy:
           requires:
             - export
+
+      - deploy:
+          deploy_args: "--prod"
+          requires:
+            - export
+          branches:
+            only:
+            - master
+
       - pdf:
           requires:
             - export

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ jobs:
         type: string
         default: ""
     docker:
-      - image: docker.pkg.github.com/tsloughter/adoptingerlang/hugo_netlify
+      - image: docker.pkg.github.com/adoptingerlang/adoptingerlang/hugo_netlify
     steps:
       - checkout
       - attach_workspace:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM circleci/node
+LABEL com.circleci.preserve-entrypoint=true
+
+USER root
+
+RUN apt-get install -f python-pygments && \
+    mkdir -p /opt && \
+    curl -L https://github.com/gohugoio/hugo/releases/download/v0.56.3/hugo_extended_0.56.3_Linux-64bit.tar.gz -o /opt/hugo.tar.gz && \
+    tar -xvf /opt/hugo.tar.gz -C /opt && \
+    npm install netlify-cli -g --unsafe-perm
+
+ENTRYPOINT ["/bin/sh"]


### PR DESCRIPTION
Merging this tomorrow morning should result in the site going live.

It also optimizes some stuff by caching emacs packages and using a custom docker file so hugo and netlify aren't installed each time.

This might break right now in the PR because the repo is private so the docker image is probably too. But will make the repo public in the morning when we are ready to go live.

Will also move everything to the adoptingerlang organization.