### PR TITLE
improved callout box styling

### DIFF
--- a/adoptingerlang.org
+++ b/adoptingerlang.org
@@ -21,13 +21,11 @@
 #+latex_header: \definecolor{friendlybg}{HTML}{f0f0f0}
 #+latex_header: \definecolor{dark}{HTML}{272822}   %% custom colour for background
 #+latex_header: \setminted{style=friendly, bgcolor=friendlybg, frame=lines, breaklines, breakanywhere}
-#+LATEX_HEADER: \newenvironment{alert}{\begin{bclogo}}{\end{bclogo}}
-#+LATEX_HEADER: \newenvironment{notice}{\begin{bclogo}}{\end{bclogo}}
+#+LATEX_HEADER: \newenvironment{admonition}{\begin{bclogo}}{\end{bclogo}}
 #+OPTIONS: ^:{}
 #+HUGO_BASE_DIR: .
 #+HUGO_SECTION: docs
-#+HUGO_PAIRED_SHORTCODES: %alert
-#+HUGO_PAIRED_SHORTCODES: %notice
+#+HUGO_PAIRED_SHORTCODES: %admonition
 #+hugo_auto_set_lastmod: t
 
 * Introduction
@@ -226,10 +224,9 @@ As you can see, the =Patch= version is not mentioned when no patch is required. 
 4. If a critical bug has been found in some circumstances, either for security or stability reasons, a patch release may be announced.
 
 #+attr_shortcode: info
-#+attr_latex: :environment bclogo :options [logo=\bcinfo, couleurBarre=orange, noborder=true, couleur=white]{Information}
-#+begin_alert
+#+begin_admonition
 Backwards incompatible changes are usually going through a cycle of deprecation before being removed, which tends to leave ample time to adapt. The policy is described in the <a href='http://erlang.org/doc/system_principles/misc.html'>Support, Compatibility, Deprecations, and Removal</a> document published by the OTP team at Ericsson.
-#+end_alert
+#+end_admonition
 
 In some rare scenarios, hard-and-fast deprecations do happen (mostly by accident), and it may take a few weeks for the community to come up with workarounds.
 
@@ -660,11 +657,10 @@ Erlang, by default, provides boot scripts that load a minimal amount of code req
 
 What we have described so far is equivalent to an operating system's kernel. We now need the foundational blocks for the userspace components. In Erlang, this is essentially what OTP is about. OTP specifies how "components" that run on the virtual machine should be structured. There's more to the language than just "processes and messages": there's one well-defined way to structure your code.
 
-#+attr_shortcode: info
-#+attr_latex: :environment bclogo :options [logo=\bcinfo, couleurBarre=orange, noborder=true, couleur=white]{Information}
-#+begin_alert
+#+attr_shortcode: note
+#+begin_admonition
 OTP stands for _Open Telecom Platform_, which is literally a meaningless name that was used to get the stuff open-sourced back in the old days of Erlang at Ericsson.
-#+end_alert
+#+end_admonition
 
 Erlang/OTP systems are structured through components named _OTP Applications_. Every Erlang version you have installed or system built with it that you use ships with a few OTP Applications. There are basically two variants of OTP applications: _Library Applications_, which are just collections of modules, and _Runnable Applications_, which contain a collection of modules, but also specify a stateful process structure stored under a supervision tree. For the sake of clarity, we're going to use the following terminology for OTP Applications for this entire book:
 
@@ -959,15 +955,14 @@ The =stop/1= callback is called _after_ the whole supervision tree has been take
 
 But all in all, this little additional =mod= line in the app file and the presence of a supervision structure are what differentiates a runnable application from a library application.
 
-#+attr_shortcode: info
-#+attr_latex: :environment bclogo :options [logo=\bcinfo, couleurBarre=orange, noborder=true, couleur=white]{Information}
-#+begin_notice
-If you do not want to care for a supervision tree and are only interested in getting a =main()= function to get going like you would in most other programming languages, =escript= might be a good option for you.
+#+attr_shortcode: tip
+#+begin_admonition
+If you do not want to care for a supervision tree and are only interested in getting a <code>main()</code> function to get going like you would in most other programming languages, <code>escript</code> might be a good option for you.
 
-escript is a special C program that wraps the Erlang virtual machine. In wrapping it, it also introduces a small shim that retrofits the idea of a main() function to the release structure, by calling your code into the root Erlang process of the virtual machine.
+<code>escript</code> is a special C program that wraps the Erlang virtual machine. In wrapping it, it also introduces a small shim that retrofits the idea of a <code>main()</code> function to the release structure, by calling your code into the root Erlang process of the virtual machine.
 
 The net result is that you can run interpreted code without having to bother about releases, OTP Applications, or supervision tree. You can read more about escripts in <a href='http://erlang.org/doc/man/escript.html'>the official Erlang documentation</a>. Rebar3 also <a href='https://www.rebar3.org/docs/commands#escriptize'>has a command to create complex escript bundles</a>.
-#+end_notice
+#+end_admonition
 
 You now understand most of the weird stuff about Erlang/OTP's project structure and everything that has to do with these mysterious "OTP Applications". Starting with next chapter, we'll start digging a bit in supervision trees, so that you know how to set things up in a stateful runnable application.
 
@@ -1303,9 +1298,8 @@ The manager can then look at whether the =sup= supervisor is alive or dead, and 
 
 This is one of the few _design patterns_ in Erlang. Because smart systems make stupid mistakes, we want to keep the supervisors as simple and predictable as they can be. The manager is us grafting a brain onto the supervisor, and making fancier decisions. This lets us separate policies for transient errors from policies for more major or persistent faults that can't just be dealt with through restarting.
 
-#+attr_shortcode: info
-#+attr_latex: :environment bclogo :options [logo=\bcinfo, couleurBarre=orange, noborder=true, couleur=white]{Information}
-#+begin_notice
+#+attr_shortcode: note
+#+begin_admonition
 This pattern can be adapted however you want. The authors have, for example, used these two other variants for restart management:
 
 <ul>
@@ -1314,7 +1308,7 @@ This pattern can be adapted however you want. The authors have, for example, use
 </ul>
 
 While it would be difficult to bake that kind of functionality in a generic supervisor, a manager can easily provide the flexibility required for tailor-made solutions of this kind.
-#+end_notice
+#+end_admonition
 
 One exercise we would recommend you do is to take your system, and then draw its supervision tree on a white board. Go through all the workers and supervisors, and ask the following questions:
 
@@ -2008,10 +2002,10 @@ One advantage of the binary data types is their ability to create subslices effi
 
 On top of that, binaries larger than 64 bytes can be shared across process heaps, so you can cheaply move string content around the virtual machine without paying the same copying cost as you would with other data structure.
 
-#+attr_shortcode: info
-#+begin_alert
+#+attr_shortcode: warning
+#+begin_admonition
 Binary sharing is often a great way to gain performance in a program. However, there exist some pathological usage patterns where binary sharing can lead to memory leaks. If you want to know more, take a look at <a href='https://www.erlang-in-anger.com/'>Erlang In Anger's</a> chapter on memory leaks, particularly section 7.2
-#+end_alert
+#+end_admonition
 
 The real cool thing though comes from the IoData representation where you combine the list approach with binaries. It's how you get really cheap composition of immutable strings:
 
@@ -2116,11 +2110,10 @@ This means that in Erlang, you'll want to use the following functions for specif
 - [[http://erlang.org/doc/man/calendar.html#local_time-0][=calendar:local_time/0=]] to return the system time converted to the operating system's current clock (meaning in the user's current timezone and daylight saving times) in a ={{Year, Month, Day},{Hour, Minute, Second}}= format
 - [[http://erlang.org/doc/man/calendar.html#universal_time-0][=calendar:universal_time/0=]] to return the system time converted to the current time in UTC in a ={{Year, Month, Day}, {Hour, Minute, Second}} format.
 
-#+attr_shortcode: info
-#+attr_latex: :environment bclogo :options [logo=\bcinfo, couleurBarre=orange, noborder=true, couleur=white]{Information}
-#+begin_notice
-The functions handling time in the <code>erlang</code> module almost all take a <code>Unit</code> argument, which can be one of <code>second</code>, <code>millisecond</code>, <code>microsecond</code>, <code>nanosecond</code>, or <code>native</code>. By default, the type of timestamp returned is in the native format. The unit is determined at run time, and <code>erlang:convert_time_unit(Time, FromUnit, ToUnit)</code> may be used to convert between time units. For example, <code>erlang:convert_time_unit(1, seconds, native)</code> returns <code>1000000000</code>.
-#+end_notice
+#+attr_shortcode: tip
+#+begin_admonition
+The functions handling time in the <code>erlang</code> module almost all take a <code>Unit</code> argument, which can be one of <code>second</code>, <code>millisecond</code>, <code>microsecond</code>, <code>nanosecond</code>, or <code>native</code>. By default, the type of timestamp returned is in the native format. The unit is determined at run time, and <code>erlang:convert&#95;time&#95;unit(Time, FromUnit, ToUnit)</code> may be used to convert between time units. For example, <code>erlang:convert&#95;time&#95;unit(1, seconds, native)</code> returns <code>1000000000</code>.
+#+end_admonition
 
 The [[http://erlang.org/doc/man/calendar.html][=calendar=]] module also contains more utility functions, such as [[http://erlang.org/doc/man/calendar.html#valid_date-1][date validation]], conversion [[http://erlang.org/doc/man/calendar.html#system_time_to_rfc3339-1][to]] and [[http://erlang.org/doc/man/calendar.html#rfc3339_to_system_time-1][from]] RFC3339 datetime strings (=2018-02-01T16:17:58+01:00=), time differences, and conversions to days, weeks, or detecting leap years.
 
@@ -2275,11 +2268,10 @@ $ rebar3 release
 
 The first =relx= step seen in the output is "Resolving OTP Applications" followed by a list of directories it will search for built applications. For each application in the =relx= release's configuration, in this case =service_discovery_postgres=, =service_discovery=, =service_discovery_http=, =service_discovery_grpc=, and =recon=, =relx= will find the directory of the built application and then do the same for any application listed in its =.app= file.
 
-#+attr_shortcode: info
-#+attr_latex: :environment bclogo :options [logo=\bcinfo, couleurBarre=orange, noborder=true, couleur=white]{Information}
-#+begin_notice
-Note that the application <code>sasl</code> is not included in the <code>relx</code> config's list of applications. By default in the Rebar3 template it is in the list. This is because <code>sasl</code> is required for certain release operations. The <code>sasl</code> application includes <code>release&#95;handler</code> which provides functionality for performing release upgrades and downgrades. Since we are focused here on creating containers which are replaced instead of live upgraded <code>sasl</code> does not need to be included.
-#+end_notice
+#+attr_shortcode: note
+#+begin_admonition
+The application <code>sasl</code> is not included in the <code>relx</code> config's list of applications. By default in the Rebar3 template it is in the list. This is because <code>sasl</code> is required for certain release operations. The <code>sasl</code> application includes <code>release&#95;handler</code> which provides functionality for performing release upgrades and downgrades. Since we are focused here on creating containers which are replaced instead of live upgraded <code>sasl</code> does not need to be included.
+#+end_admonition
 
 Because this release is built with ={dev_mode, true}=, symlinks are created in the release's lib directory that point to each application instead of being copied:
 
@@ -2298,11 +2290,10 @@ lrwxrwxrwx [...] vm.args -> [...]/config/dev_vm.args
 
 This allows for a faster feedback loop when running our release for local testing. Simply stopping and starting the release again will pick up any changes to beam files or configuration, no need to run =rebar3 release=.
 
-#+attr_shortcode: info
-#+attr_latex: :environment bclogo :options [logo=\bcinfo, couleurBarre=orange, noborder=true, couleur=white]{Information}
-#+begin_alert
+#+attr_shortcode: warning
+#+begin_admonition
 On Windows the <code>dev&#95;mode</code> of relx won't necessary work but it will fallback to copying.
-#+end_alert
+#+end_admonition
 
 The full filesystem tree of the development release now looks like:
 
@@ -2351,10 +2342,9 @@ _build/default/rel/service_discovery/
 The last directory, =sql=, is created by an =overlay=, ={copy, "apps/service_discovery_postgres/priv/migrations/*", "sql/"}=. An =overlay= tells =relx= about files to include that are outside of the regular release structure of applications and boot files. It supports making directories, basic templating with =mustache= and copying files. In this case we only need to copy the =service_discovery_postgres= application's migrations to a top level directory of the release =sql=. The migrations would be included anyway because they are in the =priv= of an application that is part of the release, but since we intend to only have one release available at a time (see notice box for more information) it simplifies the migration scripts we will see later to keep them in a known top level directory.
 
 #+attr_shortcode: info
-#+attr_latex: :environment bclogo :options [logo=\bcinfo, couleurBarre=orange, noborder=true, couleur=white]{Information}
-#+begin_notice
+#+begin_admonition
 The OTP release structure supports having multiple versions of the same release. They share the same <code>lib</code> directory but could have different versions of each application and even different <code>erts</code>. This is why there is a <code>releases</code> directory with a version number directory under it and the file <code>RELEASES</code>. Having the SQL files in a directory shared by all versions of the release could be problematic in such an environment. But since we are focused on building self contained releases that will run separately from any other in a container we can assume there is only ever one version.
-#+end_notice
+#+end_admonition
 
 Since the release uses the Postgres storage backend,a database needs to be running and accessible before starting the release. Running Docker Compose at the top level of the project will bring up a database and run the migrations:
 
@@ -2362,11 +2352,10 @@ Since the release uses the Postgres storage backend,a database needs to be runni
 $ docker-compose up
 #+END_SRC
 
-#+attr_shortcode: info
-#+attr_latex: :environment bclogo :options [logo=\bcinfo, couleurBarre=orange, noborder=true, couleur=white]{Information}
-#+begin_notice
+#+attr_shortcode: tip
+#+begin_admonition
 You don't have to start everything to get an Erlang shell from your release. Every release built with Rebar3 comes with a boot script called <code>start&#95;clean</code> which only starts the <code>kernel</code> and <code>stdlib</code> applications. This can be run with the command <code>console&#95;clean</code> and can be useful for debugging purposes.
-#+end_notice
+#+end_admonition
 
 To boot the development release to an interactive Erlang shell run the extended start script with command =console=:
 
@@ -2637,11 +2626,10 @@ Advantages of containers running with filesystem and network isolation are not h
 - Finding an open port
 - Finding a unique name for node name
 
-#+attr_shortcode: info
-#+attr_latex: :environment bclogo :options [logo=\bcinfo, couleurBarre=orange, noborder=true, couleur=white]{Information}
-#+begin_alert
+#+attr_shortcode: note
+#+begin_admonition
 You might notice we will not be using the <code>latest</code> tag at all when using Docker. This tag is commonly misunderstood and misused. It is assigned to the last image used without a specific tag, it is not the latest created image. It should rarely, if ever, be relied on, unless you really don't care what version of an image will be used.
-#+end_alert
+#+end_admonition
 
 In this chapter we will cover efficiently building images for running the [[https://adoptingerlang.org/gh/servicediscovery][service_discovery]] project as well as images for running tests and dialyzer. Then, we will update the continuous integration pipeline to build and publish new images.
 
@@ -2777,13 +2765,10 @@ The old =--cache-from= is not "multi-stage aware", meaning it requires the user 
 
 With =buildx= a cache manifest is built that will include information about previous stages in a multi-stage build. The argument =--cache-to= allows for this cache to be exported in various ways. We will use the =inline= option which writes the cache manifest directly to the image's metadata. The image can be pushed to the registry and then referenced in a later build with =--cache-from=. The unique part about the new cache manifest is that only layers that are cache hits will be downloaded, in the old form the entire image of the previous stage was downloaded when referenced by =--cache-from=.
 
-#+attr_shortcode: info
-#+attr_latex: :environment bclogo :options [logo=\bcinfo, couleurBarre=orange, noborder=true, couleur=white]{Information}
-#+begin_alert
-<h3>Caching and Security Updates</h3>
-
+#+attr_shortcode: danger "Caching and Security Updates"
+#+begin_admonition
 <p>There is a security concern to keep in mind when using layer caching. For example, since the <code>RUN</code> command only reruns if the text of the command changes, or a previous layer invalidated the cache, any system package installed will remain the same version even if a security fix has been released. For this reason it is good to occasionally run Docker with <code>--no-cache</code> which will not reuse any layers when building the image.</p>
-#+end_alert
+#+end_admonition
 
 **** Multi-Stage Build
 
@@ -2819,11 +2804,8 @@ RUN --mount=target=. \
 
 The =builder= stage starts with the base image =erlang:22-alpine=. =as builder= names the stage so we can use it as a base image to =FROM= in later stages.
 
-#+attr_shortcode: info
-#+attr_latex: :environment bclogo :options [logo=\bcinfo, couleurBarre=orange, noborder=true, couleur=white]{Information}
-#+begin_alert
-<h3>Old Docker Caching</h3>
-
+#+attr_shortcode: info "Old Docker Caching"
+#+begin_admonition
 <p>For remote caching using the old <code>--cache-from</code>, as described in the previous section,  the <code>builder</code> stage would be built and tagged with an identifier that lets us reference the image based on the Rebar3 dependencies it containers. To do this we can use the command <code>cksum</code> on <code>rebar.config</code> and <code>rebar.lock</code>. This acts similarly to what Docker does before choosing to invalidate its cache or not.</p>
 
 <code><pre>
@@ -2835,7 +2817,7 @@ $ docker push service&#95;discovery:builder-${CHKSUM}
 <p>When building any stage that uses <code>FROM builder</code> we would include <code>--cache-from=service&#95;discovery:builder-${CHKSUM}</code> to pull the previously built dependencies.</p>
 
 <p>It is common for developers to be working on concurrent branches of the same project, potentially with varying dependencies, using a checksum of the current Rebar3 config and lock files when defining the image to use as a cache allows for multiple sets of dependencies for a project to be cached and the correct set to be used when building.</p>
-#+end_alert
+#+end_admonition
 
 The next stage, named =releaser=, uses the =prod_compiled= image as its base:
 
@@ -2872,13 +2854,10 @@ This stage builds a tarball of the release using the =prod= profile:
 
 The profile having =include_erts= set to =true= means the tarball contains the Erlang runtime and can be run on a target that doesn't have Erlang installed. At the end the tarball is unpacked to =/opt/rel= so the stage that will copy the release out of the =releaser= stage does not need to have =tar= installed.
 
-#+attr_shortcode: info
-#+attr_latex: :environment bclogo :options [logo=\bcinfo, couleurBarre=orange, noborder=true, couleur=white]{Information}
-#+begin_alert
-<h3>Why tar the release at all?</h3>
-
-<p>You might notice that a tarball of the release is created only to be untarred immediately. This is done, instead of copying the contents of the release directory, for two reasons. First, it ensures only what is explicitly defined to be in this version of the release is used. This is less important when building in a docker image since no previous release builds will be in the <code>&#95;build/prod/rel</code> directory, but still good to do. Second, there are some changes made to the release when tarring that are required to use tools like <code>release&#95;handler</code>, for example the boot script is renamed from <code>RelName.boot</code> to <code>start.boot</code>. For more details see the <a href='http://erlang.org/doc/man/systools.html#make&#95;tar-1'>systools</a> documentation.</p>
-#+end_alert
+#+attr_shortcode: question "Why tar the release at all?"
+#+begin_admonition
+You might notice that a tarball of the release is created only to be untarred immediately. This is done, instead of copying the contents of the release directory, for two reasons. First, it ensures only what is explicitly defined to be in this version of the release is used. This is less important when building in a docker image since no previous release builds will be in the <code>&#95;build/prod/rel</code> directory, but still good to do. Second, there are some changes made to the release when tarring that are required to use tools like <code>release&#95;handler</code>, for example the boot script is renamed from <code>RelName.boot</code> to <code>start.boot</code>. For more details see the <a href='http://erlang.org/doc/man/systools.html#make&#95;tar-1'>systools</a> documentation.
+#+end_admonition
 
 Finally, the deployable image uses a regular OS image (=alpine:3.10=) as the base instead of a prior stage. Any shared libraries needed to run the release are installed first and then the unpacked release from the =releaser= stage is copied to =/opt/service_discovery=:
 
@@ -2991,17 +2970,14 @@ A /tmp/vm.args
 
 This can be a useful command for easily inspecting what your release is writing to disk if you run into problems or want to verify you release is not doing something it shouldn't. And in cases where there are a lot of writes to disk from the release it is best to mount a [[https://docs.docker.com/storage/volumes/][volume]] and point all writes to it, but for the 2 small configuration files this is not necessary. Unless, when creating the config files from the templates there is sensitive data being used or you want to run the container with =--read-only=. In those cases a [[https://docs.docker.com/storage/tmpfs/][tmpfs]] mount is recommended. On Linux simply add =--tmpfs /tmp= to the =docker run= command. Then =/tmp= will not be part of the writable layer of the container but a separate volume that only exists in memory and is destroyed when the container is stopped.
 
-#+attr_shortcode: info
-#+attr_latex: :environment bclogo :options [logo=\bcinfo, couleurBarre=orange, noborder=true, couleur=white]{Information}
-#+begin_alert
-<h3>Beware Zombies!</h3>
-
+#+attr_shortcode: danger "Beware Zombies!"
+#+begin_admonition
 <p>As of Erlang/OTP 19.3 an Erlang node will gracefully shutdown with <code>init:stop()</code> when a <code>TERM</code> signal is received, as is used by Docker and Kubernetes for shutting down containers.</p>
 
 <p>But there are still potential issues you will encounter with zombies in a container. When using <code>docker exec</code> to run <code>remote&#95;console</code>, or any other release script command like <code>ping</code>, will leave zombie processes behind unless the container is started with the argument <code>--init</code> that Docker offers for starting a small init before your entrypoint.</p>
 
 <p>This is usually not an issue, but like with atoms, it certainly can be if the uses aren't limited. An example of something to avoid for this reason, unless running with <code>--init</code> or some other tiny init as pid 0, would be using <code>ping</code> as a health check which is run periodically during the life of a container by the container runtime. A long running container like this will eventually have the kernel process table run out of slots and it will not be possible to create new processes.</p>
-#+end_alert
+#+end_admonition
 
 *** Building and Publishing Images in CI
 
@@ -3261,12 +3237,11 @@ envFrom:
 Now all the variables defined in the ConfigMap will be added to the container without having to individually specify each one. For more on defining ConfigMaps see the upcoming section [Using Kustomize to Simplify Deployment].
 
 #+attr_shortcode: note
-#+attr_latex: :environment bclogo :options [logo=\bcinfo, couleurBarre=orange, noborder=true, couleur=white]{Information}
-#+begin_notice
+#+begin_admonition
 <EXPLAIN THIS BETTER, maybe shouldn't be a note either but its own section in here>
 
 Rolling updates: Do not modify existing ConfigMap. Instead, create a new ConfigMap with the necessary changes and modify the ConfigMap referenced by the deployment. The old ConfigMaps will eventually be garbage collected by kubernetes since they are not referenced anywhere.
-#+end_notice
+#+end_admonition
 
 [TODO: show how to have a crashdump saved to a persistent volume]
 

--- a/layouts/shortcodes/admonition.html
+++ b/layouts/shortcodes/admonition.html
@@ -1,0 +1,4 @@
+<div class="admonition {{ .Get 0 }}">
+  <p class="admonition-title">{{ if len .Params | eq 2 }} {{ .Get 1 }} {{else}} {{ .Get 0 }} {{ end }}</p>
+  <p>{{ .Inner }}</p>
+</div>

--- a/layouts/shortcodes/alert.html
+++ b/layouts/shortcodes/alert.html
@@ -1,6 +1,0 @@
-<div class="alert {{ if .IsNamedParams }}
-{{with .Get "theme" }}alert-{{.}}{{else}}alert-info{{end}}"
-{{else}}
-	{{with .Get 0 }}alert-{{.}}{{else}}alert-info{{end}}"
-{{end}} 
-role="alert">{{.Inner}}</div>

--- a/layouts/shortcodes/notice.html
+++ b/layouts/shortcodes/notice.html
@@ -1,1 +1,0 @@
-<div class="notices {{ .Get 0 }}" {{ if len .Params | eq 2 }} id="{{ .Get 1 }}" {{ end }}>{{ .Inner }}</div>

--- a/themes/custom/assets/_admonition.scss
+++ b/themes/custom/assets/_admonition.scss
@@ -1,0 +1,103 @@
+
+$admonitions:
+    "info" rgb(0, 184, 212) "",
+    "warning" rgb(255, 145, 0) "",
+    "note" rgb(68, 138, 255) "",
+    "tip" rgb(0, 191, 165) "",
+    "danger" rgb(255, 23, 68) "",
+    "example" rgb(101, 31, 255) "",
+    "quote" rgb(158, 158, 158) "",
+    "bug" rgb(245, 0, 87) "",
+    "failure" rgb(255, 82, 82) "",
+    "success" rgb(0, 200, 83) "",
+    "question" rgb(100, 221, 23) "";
+
+@each $name, $color, $icon in $admonitions {
+    .#{$name} {
+        border-left-color: $color;
+
+        > .admonition-title {
+            background-color: transparentize($color, 0.9);
+            border-bottom-color: transparentize($color, 0.9);
+
+            &::before {
+                color: $color;
+                content: $icon;
+            }
+        }
+    }
+}
+
+.admonition {
+    border-bottom-left-radius: 2.2px;
+    border-bottom-right-radius: 2.2px;
+    border-left-style: solid;
+    border-left-width: 4px;
+    border-top-left-radius: 2.2px;
+    border-top-right-radius: 2.2px;
+    box-shadow: rgba(0, 0, 0, 0.14) 0px 2px 2px 0px, rgba(0, 0, 0, 0.12) 0px 1px 5px 0px, rgba(0, 0, 0, 0.2) 0px 3px 1px -2px;
+    box-sizing: border-box;
+    color: rgba(0, 0, 0, 0.87);
+    font-family: "Roboto", "Helvetica Neue", Helvetica, Arial, sans-serif;
+    font-feature-settings: "kern", "liga";
+    font-size: 14.0833px;
+    line-height: 22.5333px;
+    margin-bottom: 22px;
+    margin-left: 0px;
+    margin-right: 0px;
+    margin-top: 22px;
+    overflow: auto;
+    overflow-x: auto;
+    overflow-y: auto;
+    padding-bottom: 0px;
+    padding-left: 13.2px;
+    padding-right: 13.2px;
+    padding-top: 0px;
+    position: relative;
+    -moz-text-size-adjust: none;
+
+    > .admonition-title {
+        &::before {
+            box-sizing: border-box;
+            direction: ltr;
+            font-family: "Material Icons";
+            font-feature-settings: "kern", "liga";
+            font-size: 22px;
+            font-style: normal;
+            font-variant: normal;
+            font-variant-alternates: normal;
+            font-variant-caps: normal;
+            font-variant-east-asian: normal;
+            font-variant-ligatures: normal;
+            font-variant-numeric: normal;
+            font-variant-position: normal;
+            font-weight: 400;
+            left: 13.2px;
+            line-height: 22px;
+            overflow-wrap: normal;
+            position: absolute;
+            white-space: nowrap;
+            -moz-text-size-adjust: none;
+        }
+        text-transform: capitalize;
+        border-bottom-style: solid;
+        border-bottom-width: 1px;
+        box-sizing: border-box;
+        color: rgba(0, 0, 0, 0.87);
+        font-family: "Roboto", "Helvetica Neue", Helvetica, Arial, sans-serif;
+        font-feature-settings: "kern", "liga";
+        font-size: 14.0833px;
+        font-weight: 700;
+        line-height: 22.5333px;
+        margin-bottom: 0px;
+        margin-left: -13.2px;
+        margin-right: -13.2px;
+        margin-top: 0px;
+        padding-bottom: 8.8px;
+        padding-left: 44px;
+        padding-right: 13.2px;
+        padding-top: 8.8px;
+        -moz-text-size-adjust: none;
+    }
+}
+

--- a/themes/custom/assets/book.scss
+++ b/themes/custom/assets/book.scss
@@ -1,5 +1,6 @@
 @import "variables";
 @import "markdown";
+@import "admonition";
 @import "utils";
 
 html {

--- a/themes/custom/layouts/partials/docs/shared.html
+++ b/themes/custom/layouts/partials/docs/shared.html
@@ -1,7 +1,7 @@
 <!-- These templates contains some more complex logic and shared between partials-->
 {{ define "title" }}
   {{- if .Pages -}}
-    {{ $sections := split (trim .Dir "/") "/" }}
+    {{ $sections := split (trim .File.Dir "/") "/" }}
     {{ $title := index ($sections | last 1) 0 | humanize | title }}
     {{- default $title .Title -}}
   {{- else -}}


### PR DESCRIPTION
This commit adds a new shortcode, admonition, to replace notice
and alert shortcodes. It has nicer stylings, pulled from
mkdocs-material, giving the box a header and border.

Example: #+attr_shortcode: tip "This is a tip" followed by
a #+begin_admonition. The string title is optional, the
default would be the name of the styling, in this case "Tip".