### PR TITLE
Fix up copy-pasteability for Elixir rebar config

### DIFF
--- a/adoptingerlang.org
+++ b/adoptingerlang.org
@@ -1751,10 +1751,10 @@ With Elixir in place, add the [[https://www.rebar3.org/docs/configuration/plugin
 {provider_hooks, [{post, [{compile, {mix, consolidate_protocols}}]}]}.
 
 {relx, [
-    ...
+    % ...
     {overlay, [
         {copy, "{{base_dir}}/consolidated", "releases/{{release_version}}/consolidated"}
-    ]
+    ]}
 }.
 #+END_SRC
 


### PR DESCRIPTION
I blindly copied and pasted this code sample into a `rebar.config` that didn't already have relx defined. Took me a few minutes to realize that it wouldn't compile as-is :) 